### PR TITLE
ReadTools formula improvements

### DIFF
--- a/Formula/readtools.rb
+++ b/Formula/readtools.rb
@@ -4,9 +4,7 @@ class Readtools < Formula
   url "https://github.com/magicDGS/ReadTools/releases/download/1.2.1/ReadTools.jar"
   sha256 "7b0c03002377ecf12dcd22766b2e1ec1dadf0e46b4868a2938075b5c4686de7a"
 
-  head do
-    url "https://github.com/magicDGS/ReadTools.git"
-  end
+  head { url "https://github.com/magicDGS/ReadTools.git" }
 
   bottle :unneeded
 

--- a/Formula/readtools.rb
+++ b/Formula/readtools.rb
@@ -9,26 +9,19 @@ class Readtools < Formula
   depends_on :java => "1.8+"
 
   def install
-    java = share/"java"
-    java.install Dir["*.jar"]
-    bin.write_jar_script java/"ReadTools.jar", "readtools"
-  end
-
-  def post_install
-    inreplace "#{bin}/readtools", "exec java ", "exec java ${JAVA_OPTS}"
+    libexec.install "ReadTools.jar"
+    bin.write_jar_script Dir[libexec/"ReadTools.jar"][0], "readtools", "${JAVA_OPTS}"
   end
 
   def caveats
-    <<-EOS.undent
-      The ReadTools JAR files are installed to
-        #{HOMEBREW_PREFIX}/share/java
-
-      Pass java options via the environment variable JAVA_OPTS
+    <<~EOS
+      To pass java options to the readtools wrapper, use the environment variable JAVA_OPTS.
+        Example: JAVA_OPTS="-Xmx4g" readtools
     EOS
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{share}/java/ReadTools.jar -h 2>&1", 1)
-    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 1)
+    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1", 0)
+    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 0)
   end
 end

--- a/Formula/readtools.rb
+++ b/Formula/readtools.rb
@@ -4,12 +4,21 @@ class Readtools < Formula
   url "https://github.com/magicDGS/ReadTools/releases/download/1.2.1/ReadTools.jar"
   sha256 "7b0c03002377ecf12dcd22766b2e1ec1dadf0e46b4868a2938075b5c4686de7a"
 
+  head do
+    url "https://github.com/magicDGS/ReadTools.git"
+  end
+
   bottle :unneeded
 
   depends_on :java => "1.8+"
 
   def install
-    libexec.install "ReadTools.jar"
+    if build.head?
+      system "./gradlew", "currentJar"
+      libexec.install "build/libs/ReadTools.jar"
+    else
+      libexec.install "ReadTools.jar"
+    end
     bin.write_jar_script Dir[libexec/"ReadTools.jar"][0], "readtools", "${JAVA_OPTS}"
   end
 


### PR DESCRIPTION
First commit:
- Use libexec instead of share/java (part of #31)
- Simplify code for JAVA_OPTS (remove post_install)
- Re-write caveats (and fix sintax)
- Fix tests (brew test pass)
- Fix issues from "brew audit --strict" (except alias, already included)

Second commit:
- Add --HEAD install option for ReadTools