### PR TITLE
Improvements mimicree2 formula (and version bump)

### DIFF
--- a/Aliases/mimicree2@0.41
+++ b/Aliases/mimicree2@0.41
@@ -1,1 +1,0 @@
-../Formula/mimicree2.rb

--- a/Formula/mimicree2.rb
+++ b/Formula/mimicree2.rb
@@ -1,32 +1,30 @@
 class Mimicree2 < Formula
-  desc "Work in progress"
+  desc "Mimicing Experimental Evolution 2 (work in progress)"
   homepage "https://sourceforge.net/projects/mimicree2/"
-  url "https://downloads.sourceforge.net/project/mimicree2/mim2.jar"
-  version "0.41"
-  sha256 "8c6aed0ad1511a98b9240a3e98ded53ce701d967937eac1edf2980364f616783"
+  url "https://downloads.sourceforge.net/project/mimicree2/versions/mim2-v199.jar"
+  version "0.19.9"
+  sha256 "bc35350c693686c47580afa61f842f8b2a618be6ed4fe432725bfc30d31b167b"
 
   bottle :unneeded
 
   depends_on :java => ["1.8", :run]
 
   def install
-    java = share/"java"
-    java.install Dir["*.jar"]
-    bin.write_jar_script java/"mim2.jar", "mimicree2"
-    inreplace "#{bin}/mimicree2", "exec java ", "exec java ${JAVA_OPTS:--Xmx4g}"
+    libexec.install Dir["mim2-*.jar"][0]
+    bin.write_jar_script Dir[libexec/"mim2-*.jar"][0], "mimicree2", "${JAVA_OPTS:--Xmx4g}"
   end
 
   def caveats
-    <<-EOS.undent
-      The mimicree2 JAR file is installed to
-        #{HOMEBREW_PREFIX}/share/java
-      and is meant to be called via the "mimicree2" launch script.
-      Pass java options via the environment variable JAVA_OPTS.
+    <<~EOS
+      To pass and overwrite java options to the "mimicree2" wrapper,
+      use the environment variable JAVA_OPTS (default to --Xmx4g)
+        Example: JAVA_OPTS="-Xmx10g" mimicree2
     EOS
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{share}/java/mim2.jar --version 2>&1", 1)
-    assert_match "USAGE", shell_output("#{bin}/mimicree2 --version 2>&1", 1)
+    assert_match "Usage", shell_output("java -jar #{libexec}/mim2-*.jar --version 2>&1", 1)
+    assert_match "Usage", shell_output("#{bin}/mimicree2 --version 2>&1", 1)
+    assert_match "0 tests failed", shell_output("#{bin}/mimicree2 unit-tests 2>&1", 0)
   end
 end


### PR DESCRIPTION
- Remove alias (developmental version 0.*.* shouldn't have alias)
- Bump version to latest (0.1.19) - fixing download link
- Simplify formula and update caveats
- Fix brew test and brew audit issues
- Add unit-tests to brew test