### PR TITLE
Fix tap by removing wrong alias link

### DIFF
--- a/Aliases/vcflib@1.0.0
+++ b/Aliases/vcflib@1.0.0
@@ -1,1 +1,0 @@
-../Formula/vcflib.rb


### PR DESCRIPTION
Fix bug introduced by https://github.com/vetmeduni/homebrew-popgen/pull/30 (see also #39)
