### PR TITLE
Remove head in ReadTools@1.* formula

### DIFF
--- a/Formula/readtools.rb
+++ b/Formula/readtools.rb
@@ -28,7 +28,7 @@ class Readtools < Formula
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1", 0)
-    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 0)
+    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1")
+    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1")
   end
 end

--- a/Formula/readtools@1.0.rb
+++ b/Formula/readtools@1.0.rb
@@ -4,9 +4,9 @@ class ReadtoolsAT10 < Formula
   url "https://github.com/magicDGS/ReadTools/releases/download/1.0.0/ReadTools.jar"
   sha256 "f87e1c0df65680a17471e20f98155d11c3ff58f06ab8ea295ff8808f21f695a4"
 
-  keg_only :versioned_formula
-
   bottle :unneeded
+
+  keg_only :versioned_formula
 
   depends_on :java => "1.8+"
 

--- a/Formula/readtools@1.2.rb
+++ b/Formula/readtools@1.2.rb
@@ -21,7 +21,7 @@ class ReadtoolsAT12 < Formula
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1", 0)
-    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 0)
+    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1")
+    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1")
   end
 end

--- a/Formula/readtools@1.2.rb
+++ b/Formula/readtools@1.2.rb
@@ -4,19 +4,12 @@ class ReadtoolsAT12 < Formula
   url "https://github.com/magicDGS/ReadTools/releases/download/1.2.1/ReadTools.jar"
   sha256 "7b0c03002377ecf12dcd22766b2e1ec1dadf0e46b4868a2938075b5c4686de7a"
 
-  head { url "https://github.com/magicDGS/ReadTools.git" }
-
   bottle :unneeded
 
   depends_on :java => "1.8+"
 
   def install
-    if build.head?
-      system "./gradlew", "currentJar"
-      libexec.install "build/libs/ReadTools.jar"
-    else
-      libexec.install "ReadTools.jar"
-    end
+    libexec.install "ReadTools.jar"
     bin.write_jar_script Dir[libexec/"ReadTools.jar"][0], "readtools", "${JAVA_OPTS}"
   end
 

--- a/Formula/readtools@1.3.rb
+++ b/Formula/readtools@1.3.rb
@@ -20,7 +20,7 @@ class ReadtoolsAT13 < Formula
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1", 0)
-    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 0)
+    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1")
+    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1")
   end
 end

--- a/Formula/readtools@1.3.rb
+++ b/Formula/readtools@1.3.rb
@@ -3,20 +3,12 @@ class ReadtoolsAT13 < Formula
   homepage "https://magicdgs.github.io/ReadTools/"
   url "https://github.com/magicDGS/ReadTools/releases/download/1.3.0/ReadTools.jar"
   sha256 "2c8062c511b26c3dd82e3a8cd0c8dfd0af985e8e70cc994f863167ebcd8bd013"
-
-  head { url "https://github.com/magicDGS/ReadTools.git" }
-
   bottle :unneeded
 
   depends_on :java => "1.8+"
 
   def install
-    if build.head?
-      system "./gradlew", "currentJar"
-      libexec.install "build/libs/ReadTools.jar"
-    else
-      libexec.install "ReadTools.jar"
-    end
+    libexec.install "ReadTools.jar"
     bin.write_jar_script Dir[libexec/"ReadTools.jar"][0], "readtools", "${JAVA_OPTS}"
   end
 

--- a/Formula/readtools@1.4.rb
+++ b/Formula/readtools@1.4.rb
@@ -9,12 +9,7 @@ class ReadtoolsAT14 < Formula
   depends_on :java => "1.8+"
 
   def install
-    if build.head?
-      system "./gradlew", "currentJar"
-      libexec.install "build/libs/ReadTools.jar"
-    else
-      libexec.install "ReadTools.jar"
-    end
+    libexec.install "ReadTools.jar"
     bin.write_jar_script Dir[libexec/"ReadTools.jar"][0], "readtools", "${JAVA_OPTS}"
   end
 

--- a/Formula/readtools@1.4.rb
+++ b/Formula/readtools@1.4.rb
@@ -21,7 +21,7 @@ class ReadtoolsAT14 < Formula
   end
 
   test do
-    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1", 0)
-    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1", 0)
+    assert_match "USAGE", shell_output("java -jar #{libexec}/ReadTools.jar -h 2>&1")
+    assert_match "USAGE", shell_output("#{bin}/readtools -h 2>&1")
   end
 end


### PR DESCRIPTION
# FORMULA FIX

## Description
For version-pinned formulaes, there should not be a `head` to build for - that should be only available for the latest version, to build the unreleased changes. This is an issue in the `ReadTools` formulaes due to just copy-paste when uploading (see #59 for more information).

## Required
- [ ] Run `brew uninstall --force ${formula} && brew install --build-from-source ${formula}` to test clean installation
- [ ] Run `brew test ${formula}` after clean installation to run the tests
- [x] Run `brew audit --strict ${formula}` to check syntax (ignore aliases warnings)